### PR TITLE
Bunch of modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ This module is meant for use with Terraform 0.13 and further. This has been test
 
 Example of how to use this module can be found in the [example](example) folder.
 
+```hcl
+module "gcp-vpn" {
+  source  = "build-and-run/gcp-vpn/aws"
+  version = "1.0"
+
+  aws_vpc            = aws_vpc.default.id
+  gcp_network        = google_compute_network.vpc.name
+  
+  gcp_asn            = 65500
+}
+```
+
 ## Firewall rules / security group
 
 This module does no handle AWS Security Groups creation and GCP firewall rules. After setting up the VPN, you have to create them to allow traffic between your VPCs.
@@ -22,3 +34,38 @@ This module does no handle AWS Security Groups creation and GCP firewall rules. 
 ## Cloud DNS
 
 This module can route the traffic from GCP Cloud DNS to AWS using the CIDR *35.199.192.0/19*. This means you can setup Forwarding Zones in Cloud DNS and route them to AWS (provided you setup the Security Groups rules).
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | ~>3.25 |
+| google | ~> 3.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~>3.25 |
+| google | ~> 3.3 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| aws\_vpc | VPC ID for AWS | `string` | n/a | yes |
+| gcp\_asn | Google Cloud side ASN | `number` | n/a | yes |
+| gcp\_network | Network name for GCP | `string` | n/a | yes |
+| aws\_route\_tables\_ids | Routing table ID for AWS. By default it will take all the route tables in the VPC | `list(string)` | `null` | no |
+| cloud\_dns\_route\_propagation | Wether you want to add GCP Cloud DNS (35.199.192.0/19) to propagated routes, so that you can use Cloud DNS zone forwarding to AWS | `bool` | `false` | no |
+| customer | Customer applied to this instance | `string` | `""` | no |
+| environment | Environment applied to this instance | `string` | `""` | no |
+| gcp\_subnetworks | Routing table ID for AWS. By default it will take all the subnetworks in the VPC | <pre>list(object({<br>      name = string<br>      region = string<br>    }))</pre> | `null` | no |
+| ha\_vpn | Creates an HA VPN with two tunnels | `bool` | `false` | no |
+| name | Name applied to this instance | `string` | `""` | no |
+| tags | Tags applied to this instance | `map(string)` | <pre>{<br>  "ManagedBy": "terraform"<br>}</pre> | no |
+
+## Outputs
+
+No output.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # terraform-aws-gcp-vpn
 
-Terraform module to create an HA VPN between AWS and GCP
+Terraform module to create an HA VPN between AWS and GCP.
 
 The purpose of this project is to setup an HA VPN connection between AWS and GCP based on the following documentation :
 
 - [GCP  ha vpn](https://cloud.google.com/network-connectivity/docs/vpn/how-to/creating-ha-vpn)
 - [AWS vpn setup connection](https://docs.aws.amazon.com/vpn/latest/s2svpn/SetUpVPNConnections.html)
+
+## Compatibility
+
+This module is meant for use with Terraform 0.13 and further. This has been tested with provider `google` in version 3.3 and `aws` in 3.25.
+
+## Example
+
+Example of how to use this module can be found in the [example](example) folder.
+
+## Firewall rules / security group
+
+This module does no handle AWS Security Groups creation and GCP firewall rules. After setting up the VPN, you have to create them to allow traffic between your VPCs.
+
+## Cloud DNS
+
+This module can route the traffic from GCP Cloud DNS to AWS using the CIDR *35.199.192.0/19*. This means you can setup Forwarding Zones in Cloud DNS and route them to AWS (provided you setup the Security Groups rules).

--- a/aws.tf
+++ b/aws.tf
@@ -7,6 +7,7 @@ resource "aws_customer_gateway" "customer_gateway1" {
 }
 
 resource "aws_customer_gateway" "customer_gateway2" {
+  count      = var.ha_vpn ? 1 : 0
   bgp_asn    = var.gcp_asn
   ip_address = google_compute_ha_vpn_gateway.ha_vpn_gateway.vpn_interfaces[1].ip_address
   type       = "ipsec.1"
@@ -29,9 +30,10 @@ resource "aws_vpn_connection" "vpn1" {
 }
 
 resource "aws_vpn_connection" "vpn2" {
+  count      = var.ha_vpn ? 1 : 0
   vpn_gateway_id      = aws_vpn_gateway.default.id
-  customer_gateway_id = aws_customer_gateway.customer_gateway2.id
-  type                = aws_customer_gateway.customer_gateway2.type
+  customer_gateway_id = aws_customer_gateway.customer_gateway2[0].id
+  type                = aws_customer_gateway.customer_gateway2[0].type
 
   tags                = merge({ Name = var.name }, local.interpolated_tags)
 }

--- a/aws.tf
+++ b/aws.tf
@@ -36,8 +36,12 @@ resource "aws_vpn_connection" "vpn2" {
   tags                = merge({ Name = var.name }, local.interpolated_tags)
 }
 
+data "aws_route_tables" "rts" {
+  vpc_id = var.aws_vpc
+}
+
 resource "aws_vpn_gateway_route_propagation" "gcp" {
-  count                = length(var.aws_route_tables_ids)
+  for_each             = var.aws_route_tables_ids != null ? toset(var.aws_route_tables_ids) : data.aws_route_tables.rts.ids
   vpn_gateway_id       = aws_vpn_gateway.default.id
-  route_table_id       = var.aws_route_tables_ids[count.index]
+  route_table_id       = each.value
 }

--- a/aws.tf
+++ b/aws.tf
@@ -36,12 +36,8 @@ resource "aws_vpn_connection" "vpn2" {
   tags                = merge({ Name = var.name }, local.interpolated_tags)
 }
 
-resource "aws_route" "gcp" {
-  count                  = length(var.aws_route_tables_ids)
-  route_table_id         = var.aws_route_tables_ids[count.index]
-  gateway_id             = aws_vpn_gateway.default.id
-  destination_cidr_block = var.gcp_cidr
-
-  # NB: tags not supported here
-  # tags = merge({Name = var.name}, local.interpolated_tags)
+resource "aws_vpn_gateway_route_propagation" "gcp" {
+  count                = length(var.aws_route_tables_ids)
+  vpn_gateway_id       = aws_vpn_gateway.default.id
+  route_table_id       = var.aws_route_tables_ids[count.index]
 }

--- a/aws.tf
+++ b/aws.tf
@@ -15,7 +15,7 @@ resource "aws_customer_gateway" "customer_gateway2" {
 }
 
 resource "aws_vpn_gateway" "default" {
-  vpc_id = "${var.aws_vpc}"
+  vpc_id = var.aws_vpc
 
   tags   = merge({ Name = var.name }, local.interpolated_tags)
 }
@@ -41,32 +41,6 @@ resource "aws_route" "gcp" {
   route_table_id         = var.aws_route_tables_ids[count.index]
   gateway_id             = aws_vpn_gateway.default.id
   destination_cidr_block = var.gcp_cidr
-
-  # NB: tags not supported here
-  # tags = merge({Name = var.name}, local.interpolated_tags)
-}
-
-# Allow inbound access to VPC resources from GCP CIDR
-resource "aws_security_group_rule" "google_ingress_vpn" {
-  type              = "ingress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = [var.gcp_cidr]
-  security_group_id = var.aws_sg
-
-  # NB: tags not supported here
-  # tags = merge({Name = var.name}, local.interpolated_tags)
-}
-
-# Allow outbound access from VPC resources to GCP CIDR
-resource "aws_security_group_rule" "google_egress_vpn" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = [var.gcp_cidr]
-  security_group_id = var.aws_sg
 
   # NB: tags not supported here
   # tags = merge({Name = var.name}, local.interpolated_tags)

--- a/example/terraform.tf
+++ b/example/terraform.tf
@@ -54,17 +54,10 @@ resource "google_compute_subnetwork" "vpc_subnetworks" {
 
 module "gcp-vpn" {
   source  = "build-and-run/gcp-vpn/aws"
-  version = "0.2.0"
-
-  gcp_cidr = google_compute_subnetwork.vpc_subnetworks.ip_cidr_range
-
-  aws_region = "eu-west-1"
-  gcp_region = "us-east-1"
+  version = "1.0"
 
   aws_vpc            = aws_vpc.default.id
-  aws_sg             = aws_security_group.allow_nomad.id
-  aws_route_table_id = aws_vpc.default.main_route_table_id
-
-  gcp_network        = google_compute_network.vpc.id
+  gcp_network        = google_compute_network.vpc.name
+  
   gcp_asn            = 65500
 }

--- a/gcp.tf
+++ b/gcp.tf
@@ -17,6 +17,13 @@ resource "google_compute_router" "ha_vpn_gateway_router" {
       range = var.gcp_cidr
       description = var.gcp_cidr
     }
+    dynamic "advertised_ip_ranges" {
+      for_each = var.cloud_dns_route_propagation ? toset(["35.199.192.0/19"]) : toset([])
+      content {
+        range = advertised_ip_ranges.value
+        description = "Cloud DNS route propagation"
+      }
+    }
   }
 
   # NB: tags not supported here

--- a/main.tf
+++ b/main.tf
@@ -4,4 +4,5 @@ locals {
     { "Environment" = var.environment },
     var.tags
   )
+  gcp_cloud_dns = "35.199.192.0/19"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,14 +25,18 @@ variable "tags" {
 }
 
 # bellow are specific modules variables
-variable "gcp_cidr" {
-  description = "CIDR group for GCP network"
-  type        = string
-}
-
 variable "gcp_network" {
   description = "Network name for GCP"
   type        = string
+}
+
+variable "gcp_subnetworks" {
+  description = "Routing table ID for AWS. By default it will take all the subnetworks in the VPC"
+  type        = list(object({
+      name = string
+      region = string
+    }))
+  default     = null
 }
 
 variable "aws_vpc" {
@@ -41,8 +45,9 @@ variable "aws_vpc" {
 }
 
 variable "aws_route_tables_ids" {
-  description = "Routing table ID for AWS"
+  description = "Routing table ID for AWS. By default it will take all the route tables in the VPC"
   type        = list(string)
+  default     = null
 }
 
 variable "gcp_asn" {

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,9 @@ variable "cloud_dns_route_propagation" {
   type        = bool
   default     = false
 }
+
+variable "ha_vpn" {
+  description = "Creates an HA VPN with two tunnels"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -35,23 +35,8 @@ variable "gcp_network" {
   type        = string
 }
 
-variable "gcp_region" {
-  description = "Region for GCP"
-  type        = string
-}
-
-variable "aws_region" {
-  description = "Region for AWS"
-  type        = string
-}
-
 variable "aws_vpc" {
   description = "VPC ID for AWS"
-  type        = string
-}
-
-variable "aws_sg" {
-  description = "Security group for AWS Network"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "gcp_asn" {
   description = "Google Cloud side ASN"
   type        = number
 }
+
+variable "cloud_dns_route_propagation" {
+  description = "Wether you want to add GCP Cloud DNS (35.199.192.0/19) to propagated routes, so that you can use Cloud DNS zone forwarding to AWS"
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,11 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~>3.25"
     }
     google = {
       source = "hashicorp/google"
+      version = "~> 3.3"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Hello, I made a bunch of modifications on the module.

* Remove security group definition: the purpose of this module is to only create a VPN connection. Additionnally, the GCP firewall rules were not present
* Change static resource names to dynamic ones so that multiple VPN can be established
* Compatible with Terraform > 0.13 only
* Remove unused region names
* Replace static routing AWS side with route propagation from Virtual Private Gateway
* Add the possibility to route the GCP Cloud DNS CIDR through the VPN to allow Cloud DNS zone forwarding
* Removes the requirement of route tables ids and allows to specify which gcp subnetwork will be routed
* Updated Readme